### PR TITLE
Add abbreviations file

### DIFF
--- a/docs/contributing/setup-common.md
+++ b/docs/contributing/setup-common.md
@@ -16,6 +16,6 @@ changes to the sources are merged.
 ## Prerequisites
 
 If you don't yet have one, create yourself a [GitHub](https://github.com)
-account and fork the Guide repository: <https://github.com/itsnicksia/wizardry-daphne-guide>
+account and fork[^fork] the Guide repository: <https://github.com/itsnicksia/wizardry-daphne-guide>
 
-*[fork]: Create a clone of the repository
+[^fork]: Create a clone of the repository.

--- a/docs/include/abbreviations.md
+++ b/docs/include/abbreviations.md
@@ -1,0 +1,2 @@
+*[nuke]: All-rows AoE attack.
+*[AoE]: Area of Effect; something with multiple targets.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,8 @@ markdown_extensions:
   - abbr
   - pymdownx.snippets:
       base_path: docs
+      auto_append:
+        - include/abbreviations.md
   - pymdownx.caret
   - pymdownx.mark
   - pymdownx.tilde


### PR DESCRIPTION
Abbreviations are literal terms defined in a separate file and auto-included in all other files. Any listed abbreviation will be underlined and contains the description as a tooltip when hovered over.

Also change definition of "fork" to a footnote to avoid overloading.