### PR TITLE
Update bondmate quicklist details and add farming info

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ We welcome contributions and corrections by the community so don’t hesitate to
 - Maohime
 - Millaren
 - Nanashii
+- NRJank
 - Ogarith
 - Poopenheimer
 - Proto

--- a/docs/requests-bondmates/bondmates-quicklist.md
+++ b/docs/requests-bondmates/bondmates-quicklist.md
@@ -4,20 +4,41 @@
 
 | Bondmate                        | Location         | Details                                                                                                                                                                      | Effect                          | Element | Max Level |
 |:------------------------------- |:---------------- |:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |:------------------------------- |:------- |:--------- |
-| Beheading Bunny                 | Side quest       | Must fully complete the "Relentless massacre Rabbit", defeat 4 waves                                                                                                         | Critical Tolerance up           | Void    | 5         |
-| Chris the Considerate           | Hidden quest     | 2nd loop only. Loop to Fresh start, after entering the first floor, speak to him to left of entrance. Do his quest to retrieve his friend's guild tags, and he'll join.      | Mp up                           | Light   | 5         |
-| Green Jelly                     | Random encounter | On floors BF4 - BF7, you might encounter a random green slime npc. Feed it enough and it'll join.                                                                            | Defense up                      | Void    | 1         |
-| Donato, the King of Debt        | Side quest       | Must fully complete the "Donato the king of debts" quest and read his friend's letter.                                                                                       | Accuracy up                     | Dark    | 5         |
-| Gary best dogo                  | B7F              | When you get to BF7, SAVE THE DOG. But, on 2nd loop and onwards fully saving him doesn't increase bond so.........                                                           | Evasion up                      | Earth   | 1         |
-| Harry, the Wandering Adventurer | B6F              | Revive him as a dead corpse on BF6. Find him again somewhere and heal him, and find him again. He ded. He'll joined as ghost                                                 | Stun tolerance                  | Dark    | 5         |
-| Ira of the Vanished Village     | B5F              | 2nd loop only. On BF5, the bottom section, there's a fork where you can rewind a rock with a corpse. Raise her and take her to church, then keep paying child support. (500) | Divine power up                 | Water   | 5         |
-| Sir Jack, Undead Smiter         | Side quest       | Fully complete the quest "March of the Undead", defeat 4 waves                                                                                                               | Hp up                           | Fire    | 5         |
-| Mel, The Sniveling thief        | Side quest       | Fully complete the quest "Grand child Party Rescue". use delayed turns help, no one can die                                                                                  | Disarm trap up                  | Water   | 5         |
-| Mudd, the Eternal Novice        | B3F / B4F        | Mudd is an adventurer that can be rescued on floors 3 (24,16) and 4 (11,8). (X,Y) coordinates.                                                                               | Detect up                       | Air     | 5         |
-| Sir Maurice                     | Dialog option    | See chapter 1 true ending. Once rescued he might show up in the tavern and you'll get his bond.                                                                              | Resistance up                   | Earth   | 1         |
-| Albano the unlikable            | Hidden quest     | See Side quest. WIP as you need to do an annoying optional quest, will update soon.                                                                                          | Defense up and Paralysis resist | Fire    | 5         |
+| Beheading Bunny                 | Side quest       | Must fully complete the "Relentless massacre Rabbit" Request, defeat all 4 waves on B4F                                                                                                         | Critical Tolerance up           | Void    | 5         |
+| Chris the Considerate           | Hidden quest     | 2nd loop only. Loop to Fresh start. After entering the first floor, speak to him to left of entrance. Do his quest to retrieve his friend's guild tags, and he'll join.      | Mp up                           | Light   | 5         |
+| Green Jelly                     | Random encounter | On floors B4F - B7F, you might encounter a random green slime npc. Feed it enough and it'll join.                                                                            | Defense up                      | Void    | 1         |
+| Donato, the King of Debt        | Side quest       | Must fully complete the "Donato the king of debts" quest on B1F after reading his friend's letter (found on B4F).                                                                                       | Accuracy up                     | Dark    | 5         |
+| Gary best dogo                  | B7F              | When you get to B7F, SAVE THE DOG. But, on 2nd loop and onwards fully saving him doesn't increase bond so.........                                                           | Evasion up                      | Earth   | 1         |
+| Harry, the Wandering Adventurer | B6F              | Revive him as a dead corpse on B5F, find him again on B6F and heal him, and find him again on B7F. He ded. He'll joined as ghost                                                 | Stun tolerance                  | Dark    | 5         |
+| Ira of the Vanished Village     | B5F              | 2nd loop only. On BF5, the bottom section, there's a fork where you can rewind a rock with a corpse of a child. Raise her, take her to church, then keep paying child support. (500x2) Visit her after reaching B6F and again after reaching B7F. | Divine power up                 | Water   | 5         |
+| Sir Jack, Undead Smiter         | Side quest       | Fully complete the quest "March of the Undead", defeat all 4 waves on B7F.                                                                                                               | Hp up                           | Fire    | 5         |
+| Mel, The Sniveling thief        | Side quest       | Fully complete the quest "Grand child Party Rescue" on B5F. No one can die.  Use delayed turns helps.                                                                                  | Disarm trap up                  | Water   | 5         |
+| Mudd, the Eternal Novice        | B3F / B4F        | Mudd is an adventurer. Meet him on B1F, just to the right of the entry hallway. Then rescue him on B3F (6,7 or 24,16) and again on B4F (11,8). (X,Y) coordinates.                                                                               | Detect up                       | Air     | 5         |
+| Sir Maurice                     | Dialog option    | See chapter 1 true ending. Once rescued on B4F he will show up later in the tavern and you'll get his bond.                                                                              | Resistance up                   | Earth   | 1         |
+| Albano the unlikable            | Hidden quest     | See Side quest and Perfect Ending to save Albano                                                                                          | Defense up and Paralysis resist | Fire    | 5         |
 | The Pleading Boss Goblin        | B3F Goblin Den   | After saving the king, find him and fight him several times in the den. [Details here](../requests-bondmates/beginning-abyss/requests-bondmates.md#the-pleading-boss-goblin) | Surety Rate up                  | Void    | 5         |
 | Sophie the Caring               | B5F              | Save Lambert. [Details here](../requests-bondmates/beginning-abyss/requests-bondmates.md#sophie-the-caring)                                                                  | Magic Power up                  | Light   | 1         |
+
+### Farming strategy:
+Using the Cursed Wheel, Leaping back to Fresh Start will reset most bondmate locations, and then immediately Leaping forward to Warped Scene will make most bondmate Requests available.  To hit most of the bondmates, after leaping to Warped Scene:  
+1. Step right back up stairs to B7F, step into teleporter, return to Harken
+2. Leap to B5F - revive Harry and Ira.
+3. Return to town.  Visit Temple for Ira, pay 500G.
+4. Go to Guild and accept Beheading Bunny, Save the Grandchildren, and Donato Requests.
+5. Enter Abyss Entrance, take stairs to B1F.  Speak to Chris and Mudd. Complete Chris and Donato requests.
+6. Harken to B3F. Rescue Mudd.
+7. Harken to B4F. Complete all four rounds of Bunny request, get bond.  Rescue Mudd again, get bond.
+8. Stairs down to B5F. Complete Grandchildren request. (Automatically return to town.)
+9. Go to guild, turn in three requests. Get Donato and Mel bonds.  Optional - accept Abyss Heretics request. 
+10. Enter Abyss, B5F, step down to B6F. Go through full level reviving Harry when you see him.
+11. Return to town. Visit Ira at Temple, pay 500G.
+12. Enter Abyss, B7F, go find Harry one more time. Get bond.
+13. Return to town. Visit Ira at Temple, get bond.
+14. Guild - accept Undead March quest.
+15. Enter Abyss to B7F, win all 4 undead waves. Get bond. (Automatically return to town.)
+16. Repeat Cursed Wheel Leaps.
+
+Optional - Add Goblin Den to B3F part of cycle if you can avoid most fights and survive the Ambushes. (Recommend saving for levels 30 or 40.) Adding that or Albano to this gets very complicated.  Probably best to focus leveling each on their own.
 
 ## Chapter 2 Bondmates
 


### PR DESCRIPTION
- Update descriptions for Chapter 1 bondmates table.
- Connect floor numbering, e.g. BF1 -> B1F.
- Add farming cycle for level-able bondmates.
- Add name to contributor list.