### PR TITLE
statue puzzle - point to FAQ answers and update notes

### DIFF
--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -30,14 +30,16 @@ Yes! Although this isn’t something we recommend doing as the bonuses are very 
 Look around for the corpses near each teleporter room. They’ll give you a clue about which teleporter to take. Think about the position of the sun in the sky to help guide you. The first body flat out tells you to ignore one room. The second body mentions something about the light ahead. Think North. The third body mentions following the dying light. Think about a setting sun.
 
 ### How do I solve the statue puzzle on B6F of the Beginning Abyss
-This depends on the clue you get. Each statue corresponds to a member of your party when facing the teleporter. In general, you want to only repair the statue at the position that corresponds with the member that fits the clue. The answer could be that no statue gets restored.
+This depends on the clue you get, which can change everytime you enter the level. Each statue corresponds to a member of your party when facing the teleporter. In general, you want to only repair the statue at the position that corresponds with the member or members that fits the clue. The answer could be that no statue gets restored.  The elf in the Tavern will tell you about Races and Classes using the same language used in the clues.
 
-* "Ubiquitous race" = Humans
+* "Ubiquitous race" = Humans (including main character)
 * "Wise and long-lives race" = Elves
-* "Brave Fighters" = Fighter
+* "Brave Fighters" = Fighter (not Wanderer)
 * "Skillfull" = Thief
 * "Weakest" = Lowest Strength
 * "Wise" = Highest I.Q.
+
+If you get the answer right the teleporter will take you to a room with the exit stairs.  From there you will have to proceed down to B7F.
 
 ### Do I have to walk past the poison on B7F of the Beginning Abyss every time?
 No! There are 4 stone piles that you can reverse on B8F. Two of these create shortcuts to bypass the poison. Two create pathways to treasure.

--- a/docs/maps/beginning-abyss.md
+++ b/docs/maps/beginning-abyss.md
@@ -41,7 +41,7 @@
 ??? map "B6F -Map Killer-"
 
     !!! note
-        The beginning fork may varied. Don't bother opening the wrong door where the corpse tells you. It's just spikes. The corpses will give you hints to get through the level. I believe the correct warp order is right, up, then right or left depending on the previous corpse warning. (The light/sun rises in the east and sets in the west.) Statue room puzzle answer is on Discord FAQs. Saint shield quest is also completed here; do the second warp wrong and fight the mob.
+        The beginning fork may vary. Don't bother opening the wrong door where the corpse tells you. It's just spikes. The corpses will give you hints to get through the level. I believe the correct warp order is right, up, then right or left depending on the previous corpse warning. (The light/sun rises in the east and sets in the west.) Statue room puzzle requires you to restore the statue heads that match your party members according to the clue on the nearby dead body. This clue can change every time you enter this level. [See answers in the FAQ](../frequently-asked-questions.md#how-do-i-solve-the-statue-puzzle-on-b6f-of-the-beginning-abyss). Saint shield quest is also completed here; do the second warp wrong and fight the mob.
 
     ![](img/beginning-abyss/beginning-abyss-b6f.png)
 


### PR DESCRIPTION
Change the b6F map description to point to the FAQ answers for the statue puzzle instead of the Discord.  
Update some text on that FAQ item