### PR TITLE
linkify skill names

### DIFF
--- a/docs/appendices/skills-and-spells/class-skill-quicklist.md
+++ b/docs/appendices/skills-and-spells/class-skill-quicklist.md
@@ -3,22 +3,22 @@
 [List of Skill Descriptions](./skills-and-spells.md)
 
 === "Fighter Skills"
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Fighter']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Fighter']) | linkify_quicklist_skillnames | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Knight Skills"
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Knight']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Knight']) | linkify_quicklist_skillnames | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Thief Skills"
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Thief']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Thief']) | linkify_quicklist_skillnames | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Priest Skills"
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Priest']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Priest']) | linkify_quicklist_skillnames | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Mage Skills"
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Mage']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Mage']) | linkify_quicklist_skillnames | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Ninja Skills"
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Ninja']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Ninja']) | linkify_quicklist_skillnames | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Samurai Skills"
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Samurai']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Type','Level'],filter_column='Class',filter_values=['Samurai']) | linkify_quicklist_skillnames | convert_to_md_table | add_indentation(spaces=4) }}

--- a/docs/appendices/skills-and-spells/skills-and-spells.md
+++ b/docs/appendices/skills-and-spells/skills-and-spells.md
@@ -1,52 +1,52 @@
 # Skills and Spells
-
+ 
 ## Active Skills
 
 === "Skill Description"
-
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Active']) | convert_to_md_table | add_indentation(spaces=4) }}
-
+    
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Active']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
+ 
 === "Skill Source"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Active']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Active']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 
 ## Passive Skills    
 
 === "Skill Description"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Restriction','Inheritable','Effects','Detail'],filter_column='Type',filter_values=['Discipline','Passive']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Restriction','Inheritable','Effects','Detail'],filter_column='Type',filter_values=['Discipline','Passive']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Skill Source"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Discipline','Passive']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Discipline','Passive']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 ## Damage Spells
 
 === "Spell Description"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Damage']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Damage']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Spell Source"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Damage']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Damage']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 ## Heal and Buff Spells
 
 === "Spell Description"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Support']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Support']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Spell Source"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Support']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Support']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 ## Debuff Spells
 
 === "Spell Description"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Debuff']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Restriction','Effects','Detail'],filter_column='Type',filter_values=['Debuff']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}
 
 === "Spell Source"
 
-    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Debuff']) | convert_to_md_table | add_indentation(spaces=4) }}
+    {{ populate_quicklist(file='skills.csv',return_columns=['Name','Inheritable','Source','Potential Source'],filter_column='Type',filter_values=['Debuff']) | make_skillnames_linkable | convert_to_md_table | add_indentation(spaces=4) }}

--- a/main.py
+++ b/main.py
@@ -29,7 +29,6 @@ def define_env(env):
                 rarity = row['Rarity'].strip().lower()
                 name_slug = name.replace(' ', '-')
                 return f"[{name}](./{rarity}-adventurers/details/{name_slug}.md)"
-
             results['Name'] = results.apply(linkify, axis=1)
 
         return results[return_columns]
@@ -125,3 +124,16 @@ def define_env(env):
         
 
         return eqdata
+
+    @env.filter
+    def make_skillnames_linkable(df):
+        df['Name'] ='<span id = "' + df['Name'].str.replace(' ', '') + '">' + \
+                    df['Name'].astype(str) + '</span>'
+        return df
+
+    @env.filter
+    def linkify_quicklist_skillnames(df):
+        df['Name'] = '[' + df['Name'].astype(str) + ']'\
+                     + '(./skills-and-spells.md#' \
+                     + df['Name'].str.replace(' ', '') + ')'
+        return df


### PR DESCRIPTION
- add filter that makes every skill name in appendix skill list an html anchor, just removing any whitespace in skill name
e.g, Blood Edge skill can be linked to as ./skills-and-spells.md#BloodEdge

- add filter for class skills quicklist that makes every skillname a link pointing to skills as above