### PR TITLE
table sort/filter individually turned off-ablefor any table

### DIFF
--- a/docs/js/table.js
+++ b/docs/js/table.js
@@ -1,3 +1,4 @@
+/*
 document$.subscribe(function() {
     var tables = document.querySelectorAll("article table:not([class])")
     tables.forEach(function(table) {
@@ -5,3 +6,16 @@ document$.subscribe(function() {
       addFilterPlugin(table);
     })
   })
+*/
+document$.subscribe(function() {
+    var tables = document.querySelectorAll("article table:not([class])");
+    tables.forEach(function(table) {
+      // Only apply plugins if this table is NOT inside a .color-table container
+      if (!table.closest('.nosort-table')) {
+        new Tablesort(table);
+      }
+      if (!table.closest('.nofilter-table')) {
+        addFilterPlugin(table);
+      }
+    });
+});

--- a/docs/stylesheets/table-extras.css
+++ b/docs/stylesheets/table-extras.css
@@ -1,0 +1,3 @@
+.nofilter-table {}
+
+.nosort-table {}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,8 @@ extra_css:
   - stylesheets/admonition-warning.css
   - stylesheets/admonition-note.css
   - stylesheets/admonition-info.css
+  - stylesheets/table-extras.css
+
 extra_javascript:
   - js/tablefilter.js
   - js/table.js


### PR DESCRIPTION
enclosing any markdown table in div tags and assigning class name of nofilter-table and/or no-sort l-table will skip applying the js to that table. 

No impact on any other tables or normal md, js, or pandas table usage

e.g:

<div class"nofilter-table nosort-table" markdown>
| table | header | line |
| :---: | :----: | :--: |
| data  | line   | here |
</div>

the rendered markdown table will have normal formating but no filtering o sorting.