### PR TITLE
Add relicbrew farming spot list by BeautifulDemise

### DIFF
--- a/docs/adventurer-customization/relicbrew.md
+++ b/docs/adventurer-customization/relicbrew.md
@@ -435,3 +435,12 @@ Note: The stat that is negatively impacted is usually -1 per level (max of -6 at
 
 <small><sup>†</sup> SUR gives +1 from levels 1-4 and +2 at levels 5 and 6. The matching alignment bonus level is +1 SUR.<br> 
 <sup>††</sup> These are rough estimates. Could range from 0.5-1% per level.</small> 
+
+## Where to farm
+
+See the [List of Relic Power Effects](#list-of-relic-power-effects) for which monster drops each relic, and [How to Obtain Relics](#how-to-obtain-relics) for the mechanics behind when a monster can drop one.
+
+The document below suggests places to farm some of these relics. It is **updated up to Abyss 3**, so it only covers relics and spots available up to that point. Expand it to view it inline, or [open it in a new tab](https://docs.google.com/document/d/e/2PACX-1vSCQD8aLcDjKdQ2NbvgWx8_spmZP5XW7g3HoFHKZLAXiF9bjwxojl_VUX7Uk4_c-bVkadrNGy-PZxWb/pub){target="_blank" rel="noopener"}. Document courtesy of BeautifulDemise.
+
+??? note "Show BeautifulDemise's relicbrew farming list"
+    <iframe style="width: 100%; height: 40rem;" src="https://docs.google.com/document/d/e/2PACX-1vSCQD8aLcDjKdQ2NbvgWx8_spmZP5XW7g3HoFHKZLAXiF9bjwxojl_VUX7Uk4_c-bVkadrNGy-PZxWb/pub?embedded=true" loading="lazy"></iframe>

--- a/docs/strategies/farming.md
+++ b/docs/strategies/farming.md
@@ -271,4 +271,6 @@ but this requires stacking Magic Power up to around 200 for each.
         2. The ideal way to farm exp is simply going to the first star indicated on the map closest to the entrance (guaranteed fight with 3 ninjas) and then leaving + re-entering. You could technically fight every sentry on the floor up to the teleporter, but they will be slightly more difficult than the non-sentry fight near the entrance and give the same EXP.
         3. It's recommended not to go past level 50 to maximize EXP gains for this farm.
 
-    
+## Relicbrew Farming
+
+For suggested places to farm relics (used to make Relicbrews), see [Where to farm](../adventurer-customization/relicbrew.md#where-to-farm) in the Relicbrews guide.


### PR DESCRIPTION
I added BeautifulDemise's relicbrews recommended farming spots (Updated up to Abyss 3). Mentioned here: https://discord.com/channels/1296602475918524507/1410510219754082314/1435433311412551774

Think it could've helped a lot of users during the current relic drop up event, and could hopefully help in future ones.

Maybe we can replace the doc in the future with our own farming page with just the most basic, objective info (Not as detailed as the guide above)